### PR TITLE
モーダルなBottomSheetDialogFragmentを実装

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation "com.google.android.material:material:$material_version"
 
     // Fragment
-    def fragment_version = "1.2.5"
+    def fragment_version = "1.3.0-alpha08"
     implementation "androidx.fragment:fragment-ktx:$fragment_version"
 
     // Lifecycle

--- a/app/src/main/java/com/example/memom/add/AddBottomSheetDialogFragment.kt
+++ b/app/src/main/java/com/example/memom/add/AddBottomSheetDialogFragment.kt
@@ -1,0 +1,49 @@
+package com.example.memom.add
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
+import androidx.core.os.bundleOf
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.observe
+import com.example.memom.R
+import com.example.memom.databinding.AddBottomSheetDialogFragmentBinding
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class AddBottomSheetDialogFragment : BottomSheetDialogFragment() {
+
+    private val viewModel: AddViewModel by viewModels()
+    private lateinit var binding: AddBottomSheetDialogFragmentBinding
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        binding = DataBindingUtil.inflate(inflater, R.layout.add_bottom_sheet_dialog_fragment, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.viewModel = viewModel
+        binding.addEditText.requestFocus()
+        context?.getSystemService(InputMethodManager::class.java)?.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)
+        viewModel.addItem.observe(viewLifecycleOwner) {
+            setFragmentResult(REQUEST_KEY, bundleOf(BUNDLE_KEY to it))
+            dismiss()
+        }
+    }
+
+    companion object {
+
+        const val REQUEST_KEY = "AddBottomSheetDialogFragmentRequest"
+        const val BUNDLE_KEY = "AddBottomSheetDialogFragmentBundle"
+
+        fun show(fragmentManager: FragmentManager) = AddBottomSheetDialogFragment()
+            .show(fragmentManager, AddBottomSheetDialogFragment::class.java.simpleName)
+    }
+}

--- a/app/src/main/java/com/example/memom/add/AddViewModel.kt
+++ b/app/src/main/java/com/example/memom/add/AddViewModel.kt
@@ -1,0 +1,21 @@
+package com.example.memom.add
+
+import androidx.hilt.lifecycle.ViewModelInject
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.example.memom.data.entity.MemoItem
+
+class AddViewModel @ViewModelInject constructor() : ViewModel() {
+
+    val memoText = MutableLiveData<String>()
+
+    private val _addItem = MutableLiveData<MemoItem>()
+    val addItem: LiveData<MemoItem> get() = _addItem
+
+    fun saveMemoItem() {
+        memoText.value?.let {
+            _addItem.value = MemoItem(it)
+        }
+    }
+}

--- a/app/src/main/java/com/example/memom/data/entity/MemoItem.kt
+++ b/app/src/main/java/com/example/memom/data/entity/MemoItem.kt
@@ -1,5 +1,9 @@
 package com.example.memom.data.entity
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
 data class MemoItem(
     val text: String
-)
+) : Parcelable

--- a/app/src/main/java/com/example/memom/memos/MemosFragment.kt
+++ b/app/src/main/java/com/example/memom/memos/MemosFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.ItemTouchHelper.ACTION_STATE_SWIPE
@@ -18,7 +19,9 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.example.memom.R
+import com.example.memom.add.AddBottomSheetDialogFragment
 import com.example.memom.common.Binding
+import com.example.memom.data.entity.MemoItem
 import com.example.memom.databinding.FragmentMemosBinding
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -59,16 +62,16 @@ class MemosFragment : Fragment(R.layout.fragment_memos) {
                 object : SimpleCallback(UP or DOWN, LEFT or RIGHT) {
 
                     override fun onMove(recyclerView: RecyclerView, viewHolder: ViewHolder, target: ViewHolder): Boolean {
-                        viewModel.moveMemoItem(viewHolder.adapterPosition, target.adapterPosition)
+                        viewModel.moveMemoItemAt(viewHolder.adapterPosition, target.adapterPosition)
                         return true
                     }
 
                     override fun onSwiped(viewHolder: ViewHolder, direction: Int) {
                         val position = viewHolder.adapterPosition
-                        viewModel.removeMemoItem(position)?.let { removedItem ->
+                        viewModel.removeMemoItemAt(position)?.let { removedItem ->
                             Snackbar.make(view, R.string.snack_bar_delete_text, Snackbar.LENGTH_LONG)
                                 .setAnchorView(R.id.fab)
-                                .setAction(R.string.undo_delete) { viewModel.addMemoItem(position, removedItem) }
+                                .setAction(R.string.undo_delete) { viewModel.addMemoItemAt(position, removedItem) }
                                 .show()
                         }
                     }
@@ -113,5 +116,10 @@ class MemosFragment : Fragment(R.layout.fragment_memos) {
             ).attachToRecyclerView(it.memosRecyclerView)
         }
         viewModel.fetchMemoList()
+
+        childFragmentManager.setFragmentResultListener(AddBottomSheetDialogFragment.REQUEST_KEY, viewLifecycleOwner) { _, result ->
+            val item = result.getParcelable<MemoItem>(AddBottomSheetDialogFragment.BUNDLE_KEY) ?: return@setFragmentResultListener
+            viewModel.addMemoItem(item)
+        }
     }
 }

--- a/app/src/main/java/com/example/memom/memos/MemosFragment.kt
+++ b/app/src/main/java/com/example/memom/memos/MemosFragment.kt
@@ -50,7 +50,7 @@ class MemosFragment : Fragment(R.layout.fragment_memos) {
             }
 
             it.fab.setOnClickListener {
-                // TODO: Add fab handle
+                AddBottomSheetDialogFragment.show(childFragmentManager)
             }
 
             it.memosRecyclerView.layoutManager = LinearLayoutManager(context)

--- a/app/src/main/java/com/example/memom/memos/MemosViewModel.kt
+++ b/app/src/main/java/com/example/memom/memos/MemosViewModel.kt
@@ -31,14 +31,14 @@ class MemosViewModel @ViewModelInject constructor(
         }
     }
 
-    fun moveMemoItem(fromPosition: Int, toPosition: Int) {
+    fun moveMemoItemAt(fromPosition: Int, toPosition: Int) {
         _memoList.value?.toMutableList()?.let {
             it.add(toPosition, it.removeAt(fromPosition))
             _memoList.value = it
         }
     }
 
-    fun removeMemoItem(position: Int): MemoItem? {
+    fun removeMemoItemAt(position: Int): MemoItem? {
         _memoList.value?.toMutableList()?.let {
             val removedItem = it.removeAt(position)
             _memoList.value = it
@@ -46,7 +46,14 @@ class MemosViewModel @ViewModelInject constructor(
         } ?: return null
     }
 
-    fun addMemoItem(position: Int, item: MemoItem) {
+    fun addMemoItem(item: MemoItem) {
+        _memoList.value?.toMutableList()?.let {
+            it.add(item)
+            _memoList.value = it
+        }
+    }
+
+    fun addMemoItemAt(position: Int, item: MemoItem) {
         _memoList.value?.toMutableList()?.let {
             it.add(position, item)
             _memoList.value = it

--- a/app/src/main/res/layout/add_bottom_sheet_dialog_fragment.xml
+++ b/app/src/main/res/layout/add_bottom_sheet_dialog_fragment.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    >
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.example.memom.add.AddViewModel"
+            />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingVertical="16dp"
+        >
+
+        <androidx.appcompat.widget.AppCompatEditText
+            android:id="@+id/add_edit_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="24dp"
+            android:layout_marginBottom="24dp"
+            android:text="@={ viewModel.memoText }"
+            android:background="@null"
+            app:layout_constraintBottom_toTopOf="@id/add_button"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            />
+
+        <com.google.android.material.button.MaterialButton
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:id="@+id/add_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="24dp"
+            android:text="@string/save_memo"
+            android:onClick="@{ () -> viewModel.saveMemoItem() }"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="option">オプション</string>
     <string name="snack_bar_delete_text">メモを削除しました</string>
     <string name="undo_delete">元に戻す</string>
+    <string name="save_memo">保存</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,6 +6,16 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorPrimary</item>
         <item name="colorSecondary">@color/colorPrimary</item>
+        <item name="bottomSheetDialogTheme">@style/BottomSheetDialogTheme</item>
+    </style>
+
+    <style name="BottomSheetDialogTheme" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorPrimary</item>
+        <item name="colorSecondary">@color/colorPrimary</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowSoftInputMode">adjustResize</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## BottomSheetDialogFragment

モーダルなボトムシートを表示するダイアログ。
https://material.io/develop/android/components/bottom-sheet-dialog-fragment

非モーダルなボトムシートを実装するには、BottomSheetBehaviorを用いる(CoordinatorLayoutが必要)
https://material.io/develop/android/components/sheets-bottom

1. サブクラスにBottomSheetDialogFragmentを継承したクラスを作成
2. onCreateView()をオーバーライドし、適切なViewを返す
3. 遷移元からBottomSheetDialogFragmentをshow()する

<img width="320" src="https://user-images.githubusercontent.com/28253842/94371792-18be8b80-0134-11eb-9490-f48a5b1a1df1.gif">